### PR TITLE
Flask webapi PoC w/ Swagger

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,8 @@ dependencies:
       - pytest
       - pytest-asyncio
       - pytest-mock
+      - flask
+      - flask-openapi3
+      - flask-openapi3[swagger]
 
 prefix: /opt/anaconda3/envs/condor

--- a/src/forgd_core/webapi/webapi.py
+++ b/src/forgd_core/webapi/webapi.py
@@ -1,0 +1,93 @@
+from enum import Enum
+from typing import Dict
+from pydantic import BaseModel, Field
+
+from flask import jsonify
+from flask_openapi3 import Info, Tag
+from flask_openapi3 import OpenAPI
+
+from decimal import Decimal
+
+from forgd_core.curves.single.linear import LinearBondingCurve
+from forgd_core.common.model import (
+    BondingCurveParams,
+    BondingCurveState,
+    Token,
+    TransactionRequest,
+)
+from forgd_core.common.enums import BondingCurveType, OrderSide
+
+
+info = Info(title="Bonding Curve API", version="1.0.0")
+app = OpenAPI(__name__, info=info)
+
+
+class CurveTransactionAction(Enum):
+    buy = "buy"
+    sell = "sell"
+
+
+class CurveType(Enum):
+    linear = "linear"
+
+
+class CurveTransactionRequest(BaseModel):
+    curve_type: CurveType = Field(description="The bonding curve type to use")
+    curve_params: Dict = Field(None)
+    allocated_supply: Decimal = Field(description="Already allocated token supply")
+    action: CurveTransactionAction = Field(description="API action to perform")
+    amount: Decimal = Field(description="amount to buy / sell")
+
+
+curve_action_tag = Tag(
+    name="curve_tx",
+    description="Perform a buy or sell transaction on a bonding curve and get execution pricing information",
+)
+
+
+@app.get("/curve/transaction", summary="Curve Transaction", tags=[curve_action_tag])
+def transaction(query: CurveTransactionRequest):
+    """
+    Handles a buy or sell operation on a curve
+    """
+    if query.curve_type != CurveType.linear:
+        return jsonify({})
+
+    params = BondingCurveParams(
+        curve_type=BondingCurveType.from_str(query.curve_type.value)
+    )
+    state = BondingCurveState(current_supply=Decimal(query.allocated_supply))
+
+    curve = LinearBondingCurve(params, state)
+    dummy_token = Token("dummy", "dummy", 8)
+
+    side = OrderSide.from_str(query.action.name)
+
+    req_inner = TransactionRequest(dummy_token, side, query.amount)
+    result = curve.buy(req_inner)
+    return jsonify(result)
+
+
+class CurveStatusRequest(BaseModel):
+    curve_type: CurveType = Field(description="The bonding curve type to use")
+    curve_params: Dict = Field(None)
+    allocated_supply: Decimal = Field(description="Already allocated token supply")
+
+
+curve_status_tag = Tag(
+    name="curve_status",
+    description="Get the shape of a bonding curve for plotting and additional info",
+)
+
+
+@app.get("/curve/status", summary="Curve Status", tags=[curve_status_tag])
+def status(query: CurveStatusRequest):
+    """
+    Return a representation of the curve which can be plotted visually by the caller.
+    Return the 'midprice' of the curve based on the allocated amount specified by the caller.
+    """
+    return jsonify("TODO")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/src/forgd_core/webapi/webapi.py
+++ b/src/forgd_core/webapi/webapi.py
@@ -40,18 +40,18 @@ class CurveTransactionRequest(BaseModel):
 
 
 curve_action_tag = Tag(
-    name="curve_tx",
-    description="Perform a buy or sell transaction on a bonding curve and get execution pricing information",
+    name="Bonding Curve Transaction",
+    description="Perform a buy or sell transaction on a curve and get the execution information",
 )
 
 
-@app.get("/curve/transaction", summary="Curve Transaction", tags=[curve_action_tag])
+@app.post("/curve/transaction", summary="Curve Transaction", tags=[curve_action_tag])
 def transaction(query: CurveTransactionRequest):
     """
     Handles a buy or sell operation on a curve
     """
     if query.curve_type != CurveType.linear:
-        return jsonify({})
+        return jsonify("err")
 
     params = BondingCurveParams(
         curve_type=BondingCurveType.from_str(query.curve_type.value)
@@ -64,6 +64,7 @@ def transaction(query: CurveTransactionRequest):
     side = OrderSide.from_str(query.action.name)
 
     req_inner = TransactionRequest(dummy_token, side, query.amount)
+
     result = curve.buy(req_inner)
     return jsonify(result)
 
@@ -75,10 +76,9 @@ class CurveStatusRequest(BaseModel):
 
 
 curve_status_tag = Tag(
-    name="curve_status",
+    name="Bonding Curve Status",
     description="Get the shape of a bonding curve for plotting and additional info",
 )
-
 
 @app.get("/curve/status", summary="Curve Status", tags=[curve_status_tag])
 def status(query: CurveStatusRequest):


### PR DESCRIPTION
A quick PoC of a web api for client interactions with a swagger apidocs endpoint to aid query testing.

High level design is a `transaction` endpoint for buy/sell execution information and a `status` endpoint which returns a representation of the curve for the caller to plot (we can discretise at some $ bin size).

I would recommend we have the caller pass in all the information we need via the API each time it makes a query (curve config, max supply - EVERYTHING!) - this means we remain stateless and don't need to host a database to keep track of specifics / worry about access control etc.

The model and enums used here are deliberately kept separate from the "core" ones, so that the web api can evolve independently from the core logic. Will probably keep a `webapi/model.py` module to keep these, I've kept them in the one file for now so you can see how it all fits together.

The swagger UI is pretty cool for testing:

```
cd src/forgd_core/webapi
python webapi.py
open http://127.0.0.1:5000/openapi/
```

![Screenshot 2025-03-10 at 17 39 22](https://github.com/user-attachments/assets/9ec04be0-30f9-470b-9ac2-bbb773ea799f)

